### PR TITLE
removed restriction on shortened course name on course card

### DIFF
--- a/templates/block_myoverview/view-cards.mustache
+++ b/templates/block_myoverview/view-cards.mustache
@@ -51,7 +51,8 @@
     {{/progress}}
     {{$coursename}}
         <span class="multiline">
-            {{#shortentext}}50, {{{fullname}}} {{/shortentext}}
+           <!-- {{#shortentext}}50, {{{fullname}}} {{/shortentext}} -->
+		{{fullname}}
         </span>
     {{/coursename}}
     {{$coursecategory}}


### PR DESCRIPTION
Hi Patrick, I removed the restriction on coursename on the cards view. 