### PR TITLE
updated course menu MORE button links to not be escaped

### DIFF
--- a/templates/course_navbar.mustache
+++ b/templates/course_navbar.mustache
@@ -190,7 +190,7 @@
                                 <div class="dropdown-menu" aria-labelledby="courseAssignments">
                                     {{#more_menu}}
                                         <a class="dropdown-item"
-                                           href="{{url}}"
+                                           href="{{{url}}}"
                                            title="{{name}}">{{name}}</a>
                                     {{/more_menu}}
                                 </div>


### PR DESCRIPTION
Fixes issue with Badge url having erroneous 'amp;' in there.