### PR TITLE
atto full screen fixes

### DIFF
--- a/scss/default.scss
+++ b/scss/default.scss
@@ -18,3 +18,4 @@
 @import "moove/profile";
 @import "moove/enrol";
 @import "moove/activityicons";
+@import "moove/atto";

--- a/scss/moove/_atto.scss
+++ b/scss/moove/_atto.scss
@@ -1,0 +1,5 @@
+
+/* atto full screen fix */
+.editor_atto_wrap {
+    z-index: 1000
+}

--- a/scss/moove/_atto.scss
+++ b/scss/moove/_atto.scss
@@ -1,5 +1,8 @@
-
 /* atto full screen fix */
-.editor_atto_wrap {
-    z-index: 1000
+.atto-fullscreen .editor_atto_wrap div.editor_atto {
+    z-index: 1001;
+}
+
+.atto-fullscreen .editor_atto_wrap .CodeMirror-wrap {
+    z-index: 1001;
 }


### PR DESCRIPTION
Hi @patrickthibaudeau, there was an issue with the atto html/text editor text when in fullscreen colliding with our secondary nav so in fullscreen I changed the z-index. I had this code done a while back but never merged etc.